### PR TITLE
Dev/rate limiter

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -4,6 +4,7 @@
  * @author Jon Arild Nygard
  * @todo Add license
  */
+
 'use strict'
 
 // Import dependencies, sorted by path name.
@@ -18,6 +19,11 @@ const {
 } = require('./handlers.js')
 const { Router } = require('express')
 
+// Middleware
+const rateLimit = require('express-rate-limit')
+const slowDown = require('express-slow-down')
+const { log } = require('./utilities')
+
 // Constants
 const ROUTER = Router()
 
@@ -27,6 +33,37 @@ ROUTER.post('/update', catchAsyncErrors(handlerUpdate))
 ROUTER.get('/favicon.ico', catchAsyncErrors(handlerIcon))
 ROUTER.get('/robots.txt', catchAsyncErrors(handlerRobots))
 ROUTER.get('/', catchAsyncErrors(handlerIndex))
+
+const skip = req => {
+  // allow requests with allowed referers
+  const referer = req.get('Referer')
+  const allowedReferer = referer ? ['highcharts.local', 'highcharts.com']
+    .some((url) => referer.includes(url)) : false
+
+  if (allowedReferer) {
+    log(1, `skipping rate limiter for referer ${referer}`)
+    return true
+  }
+  return false
+}
+
+// Slow down after 30 requests
+// Delay is cumulative
+ROUTER.use('*', slowDown({
+  windowMs: 15 * 60 * 1000,
+  delayAfter: 30,
+  delayMs: 500,
+  skip
+}))
+
+// limit after 50 requests
+ROUTER.use('*', rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 50,
+  message: `github.highcharts.com is intended for testing only.
+Use code.highcharts.com for production environments`,
+  skip
+}))
 ROUTER.get('*', catchAsyncErrors(handlerDefault))
 
 // Export the router

--- a/app/router.js
+++ b/app/router.js
@@ -47,23 +47,31 @@ const skip = req => {
   return false
 }
 
-// Slow down after 30 requests
-// Delay is cumulative
+// Separate limit for each file requested
+const keyGenerator = (req) => {
+  return req.ip + req.baseUrl
+}
+
+// Slow down after 15 requests
+// Delay is cumulative up to 2s
 ROUTER.use('*', slowDown({
   windowMs: 15 * 60 * 1000,
-  delayAfter: 30,
+  delayAfter: 15,
   delayMs: 500,
+  keyGenerator,
   skip
 }))
 
-// limit after 50 requests
+// limit after 30 requests
 ROUTER.use('*', rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 50,
+  max: 30,
   message: `github.highcharts.com is intended for testing only.
 Use code.highcharts.com for production environments`,
+  keyGenerator,
   skip
 }))
+
 ROUTER.get('*', catchAsyncErrors(handlerDefault))
 
 // Export the router

--- a/app/server.js
+++ b/app/server.js
@@ -16,13 +16,46 @@ const {
   setConnectionAborted
 } = require('./middleware.js')
 const router = require('./router.js')
-const { formatDate, log } = require('./utilities.js')
+const { formatDate, log, compileTypeScript } = require('./utilities.js')
 const express = require('express')
 
 // Constants
 const APP = express()
 const PORT = process.env.PORT || config.port || 80
 const DATE = formatDate(new Date())
+
+const state = {
+  typescriptJobs: {}
+}
+
+/**
+ * Adds the compilation of the branch to the job registry
+ * Returns the promise
+ * @param {string} branch
+ * @returns {Promise}
+ */
+function addTypescriptJob (branch) {
+  if (!state.typescriptJobs[branch]) {
+    const job = state.typescriptJobs[branch] = compileTypeScript(branch)
+    return job
+  }
+}
+
+/**
+ * Removes a job from the registry
+ * @param {*} branch
+ */
+function removeTypescriptJob (branch) {
+  if (state.typescriptJobs[branch]) delete state.typescriptJobs[branch]
+}
+
+/**
+ * Returns a job from the registry
+ * @param {*} branch
+ */
+function getTypescriptJob (branch) {
+  return state.typescriptJobs[branch]
+}
 
 // Output status information
 log(2, `
@@ -54,3 +87,11 @@ APP.use(logErrors)
  * Start the server
  */
 APP.listen(PORT)
+
+module.exports = {
+  default: APP,
+  getTypescriptJob,
+  addTypescriptJob,
+  removeTypescriptJob,
+  state
+}

--- a/app/utilities.js
+++ b/app/utilities.js
@@ -7,6 +7,7 @@
 
 const childProcess = require('child_process')
 const fs = require('fs').promises
+const util = require('util')
 
 // Import dependencies, sorted by path.
 const config = require('../config.json')
@@ -152,8 +153,8 @@ function padStart (str, length = 0, char) {
  * @param {String} branch to specific commit, tag or branch
  */
 function compileTypeScript (branch) {
-  console.log(`Compiling TypeScript for downloaded folder ${branch}..`)
-  childProcess.execSync(`npx tsc --project tmp/${branch}/ts/tsconfig.json`)
+  log(0, `Compiling TypeScript for downloaded folder ${branch}..`)
+  return util.promisify(childProcess.exec)(`npx tsc --project tmp/${branch}/ts/tsconfig.json --skipLibCheck`)
 }
 
 async function getGlobalsLocation (filePath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github.highcharts.com",
-  "version": "1.7.9",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -694,6 +694,11 @@
         }
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1006,6 +1011,14 @@
       "dev": true,
       "requires": {
         "strip-bom": "^3.0.0"
+      }
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -1666,6 +1679,19 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "express-rate-limit": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.1.3.tgz",
+      "integrity": "sha512-TINcxve5510pXj4n9/1AMupkj3iWxl3JuZaWhCdYDlZeoCPqweGZrxbrlqTCFb1CT5wli7s8e2SH/Qz2c9GorA=="
+    },
+    "express-slow-down": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/express-slow-down/-/express-slow-down-1.3.1.tgz",
+      "integrity": "sha512-mkxVJt3z2e0/LIVp144xpaPw8Ku2f6XS9ftjgwMsUtp+4a84hk6NI6/KTEPkq1kjCsJuXeG6SA/izCWxaErBdg==",
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "external-editor": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "express-rate-limit": "^5.1.3",
+    "express-slow-down": "^1.3.1",
     "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.3.3",
     "typescript": "^3.9.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github.highcharts.com",
-  "version": "1.7.9",
+  "version": "1.8.1",
   "description": "Node.js server which runs a RESTful application to serve Highcharts scripts built from the Highcharts build script.",
   "main": "server.js",
   "dependencies": {

--- a/test/artillery-load-test.yml
+++ b/test/artillery-load-test.yml
@@ -1,0 +1,16 @@
+# run with `npx artillery run ./test/artillery-load-test.yml`
+
+config:
+  target: http://localhost:90
+  phases:
+    - duration: 30
+      arrivalRate: 5
+      arrivalCount: 10 # queries over 60 seconds per '- get'
+scenarios:
+  - flow:
+      - get:
+          url: "/highcharts.src.js"
+      - get:
+          url: "/v8.2.2/highcharts.src.js"
+      - get:
+          url: "/v5.0.0/highcharts.src.js"

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,19 @@
+const { describe, it } = require('mocha')
+const { ok, strictEqual } = require('assert')
+const { addTypescriptJob, removeTypescriptJob, state } = require('../app/server')
+
+describe('typescript job registry', () => {
+  it('should add typescript job', () => {
+    addTypescriptJob('master')
+    ok(state.typescriptJobs['master'])
+  })
+  it('should not update value when same jobname is given', () => {
+    const og = state.typescriptJobs['master']
+    addTypescriptJob('master')
+    strictEqual(og, state.typescriptJobs['master'])
+  })
+  it('should remove typescript job', () => {
+    removeTypescriptJob('master')
+    strictEqual(state.typescriptJobs['master'], undefined)
+  })
+})


### PR DESCRIPTION
Added slowdown and rate limiting. Starts slowing down each response after 15 requests for a file in a 15 minute period. After 30 requests they will be cut off.

Requests with referers including 'highcharts.local' or 'highcharts.com' will be skipped.