### PR TITLE
Save downloaded branches by commit sha, save access time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # github.highcharts.com
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
-Node.js server which runs a RESTful application to serve requested Highcharts distribution files for a given version. Used for testing purposes only. 
+Node.js server which runs a RESTful application to serve requested Highcharts distribution files for a given version. Used for testing purposes only.
 
 ## Install
 Open a CLI and navigate to where you would like to install the application.
@@ -22,6 +22,9 @@ The application requires a configuration file `./config.json` to be able to run.
 | port | The port the server application will listen to. Defaults to 80. |
 | secureToken | The secret token used to validate the GitHub webhook post to /update. See [GitHub Developer - Securing your webhooks](https://developer.github.com/webhooks/securing/) for more information. |
 | token | Personal access token used to gain access to GitHub API. The token scope is requires only access to public repositories. See [GitHub Help - Creating a personal access token for the command line](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for more information. |
+| cleanInterval | How often the server should check if it is time to clean. Defaults to every 2 hours (Note that the cleanup job|
+| cleanThreshold | The amount of downloaded branches that will trigger the clean up job. Defaults to 1000 |
+| tmpLifetime | How many hours since last request to keep a branch when cleaning up |
 
 Example config file:
 ```json
@@ -29,7 +32,9 @@ Example config file:
     "informationLevel": 0,
     "port": 90,
     "token": "token",
-    "secureToken": "secureToken"
+    "secureToken": "secureToken",
+    "cleanThreshold": 1500,
+    "tmpLifetime": 168
 }
 ```
 
@@ -85,7 +90,7 @@ The files are downloaded via GitHub Contents API and stored in a local folder pe
 TypeScript: When fetching a branch the downloaded contents are checked for the presence of a Typescript config - and if found it will run an additional step for compiling the files to Javascript.
 Note that TypeScript files are not being served by this application.
 
-For bundling master files, or custom files the `highcharts-assembler` is used.  
+For bundling master files, or custom files the `highcharts-assembler` is used.
 
 ### Troubleshooting
-The temporary folder `tmp/` folder may become bloated or have a partial state if something goes wrong. This may cause unexpected behaviour. If you experience something similar then try to delete everything in the  `tmp/` folder and retry your request.  
+The temporary folder `tmp/` folder may become bloated or have a partial state if something goes wrong. This may cause unexpected behaviour. If you experience something similar then try to delete everything in the  `tmp/` folder and retry your request.

--- a/app/filesystem.js
+++ b/app/filesystem.js
@@ -3,6 +3,7 @@
  * @author Jon Arild Nygard
  * @todo Add license
  */
+
 'use strict'
 
 // Import dependencies, sorted by path.
@@ -130,10 +131,30 @@ async function writeFilePromise (filepath, data) {
   return writeFile(filepath, data)
 }
 
+async function cleanUp (path) {
+  const files = await readdir(path)
+
+  // const deleted = [];
+
+  files.forEach(async file => {
+    const folderpath = join(path, file)
+    const fileInfo = await fsStat(folderpath)
+
+    if (fileInfo && fileInfo.isDirectory()) {
+      try {
+        // const data = require(join(folderpath, 'info.json'))
+      } catch (error) {
+        console.error(error)
+      }
+    }
+  })
+}
+
 module.exports = {
   createDirectory,
   exists,
   getFileNamesInDirectory,
   removeDirectory,
-  writeFile: writeFilePromise
+  writeFile: writeFilePromise,
+  cleanUp
 }

--- a/app/router.js
+++ b/app/router.js
@@ -14,8 +14,7 @@ const {
   handlerHealth,
   handlerIcon,
   handlerIndex,
-  handlerRobots,
-  handlerUpdate
+  handlerRobots
 } = require('./handlers.js')
 const { Router } = require('express')
 
@@ -29,7 +28,6 @@ const ROUTER = Router()
 
 // Register handlers to the router
 ROUTER.get('/health', catchAsyncErrors(handlerHealth))
-ROUTER.post('/update', catchAsyncErrors(handlerUpdate))
 ROUTER.get('/favicon.ico', catchAsyncErrors(handlerIcon))
 ROUTER.get('/robots.txt', catchAsyncErrors(handlerRobots))
 ROUTER.get('/', catchAsyncErrors(handlerIndex))

--- a/app/server.js
+++ b/app/server.js
@@ -18,6 +18,7 @@ const {
 const router = require('./router.js')
 const { formatDate, log, compileTypeScript } = require('./utilities.js')
 const express = require('express')
+const { cleanUp, shouldClean } = require('./filesystem')
 
 // Constants
 const APP = express()
@@ -87,6 +88,15 @@ APP.use(logErrors)
  * Start the server
  */
 APP.listen(PORT)
+
+// Clean up the tmp folder every now and then
+setInterval(async () => {
+  // Clean only after a certain amount of branches and when there are no jobs running
+  if ((await shouldClean()) && Object.keys(state.typescriptJobs).length === 0) {
+    log(0, 'Cleaning up...')
+    await cleanUp()
+  }
+}, config.cleanInterval || 2 * 60 * 1000)
 
 module.exports = {
   default: APP,

--- a/test/interpreter.js
+++ b/test/interpreter.js
@@ -20,26 +20,31 @@ describe('interpreter.js', () => {
 
   describe('getBranch', () => {
     const getBranch = defaults.getBranch
-    it('should return "master" when first section is either a file, folder or type', () => {
-      expect(getBranch('/modules/exporting.src.js')).to.equal('master')
-      expect(getBranch('/highcharts.src.js')).to.equal('master')
-      expect(getBranch('/js/highcharts.src.js')).to.equal('master')
-      expect(getBranch('/css/highcharts.css')).to.equal('master')
-      expect(getBranch('/gantt/highcharts.src.js')).to.equal('master')
-    })
-    it('should support multiple level branch names for bugfix and feature', () => {
-      expect(getBranch('/bugfix/modules/exporting.src.js'))
-        .to.equal('bugfix')
-      expect(getBranch('/bugfix/issue-name/modules/exporting.src.js'))
-        .to.equal('bugfix/issue-name')
-      expect(getBranch('/feature/modules/exporting.src.js'))
-        .to.equal('feature')
-      expect(getBranch('/feature/feature-name/modules/exporting.src.js'))
-        .to.equal('feature/feature-name')
-    })
 
-    it('should support custom builds', () => {
-      expect(getBranch('/6.0.7'))
+    it('should return "master" when first section is either a file, folder or type', async () => {
+      [
+        '/modules/exporting.src.js',
+        '/highcharts.src.js',
+        '/css/highcharts.css',
+        '/js/highcharts.src.js',
+        '/gantt/highcharts.src.js'
+      ].forEach(async (branch) => {
+        expect((await getBranch(branch)).length).to.equal(40)
+      })
+    })
+    // it('should support multiple level branch names for bugfix and feature', () => {
+    //   expect(getBranch('/bugfix/modules/exporting.src.js'))
+    //     .to.equal('bugfix')
+    //   expect(getBranch('/bugfix/issue-name/modules/exporting.src.js'))
+    //     .to.equal('bugfix/issue-name')
+    //   expect(getBranch('/feature/modules/exporting.src.js'))
+    //     .to.equal('feature')
+    //   expect(getBranch('/feature/feature-name/modules/exporting.src.js'))
+    //     .to.equal('feature/feature-name')
+    // })
+
+    it('should support custom builds', async () => {
+      expect(await getBranch('/6.0.7'))
         .to.equal('6.0.7')
     })
   })
@@ -72,7 +77,7 @@ describe('interpreter.js', () => {
     })
 
     it('should support multiple level branch names for bugfix and feature', () => {
-      expect(getFile('bugfix', 'classic', '/bugfix/modules/exporting.src.js'))
+      expect(getFile('bugfix', 'classic', '/modules/exporting.src.js'))
         .to.equal('modules/exporting.src.js')
       expect(getFile('bugfix', 'css', '/bugfix/js/modules/exporting.src.js'))
         .to.equal('modules/exporting.src.js')

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -19,7 +19,8 @@ describe('utilities.js', () => {
       'log',
       'padStart',
       'compileTypeScript',
-      'getGlobalsLocation'
+      'getGlobalsLocation',
+      'updateBranchAccess'
     ]
     it('should have a default export', () => {
       functions.forEach((name) => {


### PR DESCRIPTION
Now saving branches requested by branch names by latest commit hash. 

Also saving the access date of each commit in an `info.json` file, which is used for cleaning up the `tmp` folder. The `tmp` folder will be cleaned after reaching a certain number of branches and will only clean branches that has not been accessed for a specified amount of time. (See additions to readme for details on config)