### PR TITLE
Ts refactor

### DIFF
--- a/app/download.js
+++ b/app/download.js
@@ -66,6 +66,7 @@ function downloadFiles (baseURL, subpaths, outputDir) {
  * @param {string} branch The name of the branch the files are located in.
  */
 async function downloadSourceFolder (outputDir, repositoryURL, branch) {
+  log(0, `Downloading source for commit ${branch}`)
   const url = `${repositoryURL}${branch}`
   const files = await getDownloadFiles(branch)
   const responses = await downloadFiles(url, files, outputDir)

--- a/app/handlers.js
+++ b/app/handlers.js
@@ -9,7 +9,7 @@
 // Import dependencies, sorted by path name.
 const { secureToken } = require('../config.json')
 const { downloadFile, downloadSourceFolder, urlExists } = require('./download.js')
-const { compileTypeScript, getGlobalsLocation, log, updateBranchAccess } = require('./utilities')
+const { compileTypeScriptProject, getGlobalsLocation, log, updateBranchAccess } = require('./utilities')
 
 const {
   exists,
@@ -271,48 +271,53 @@ async function serveBuildFile (repositoryURL, requestURL) {
   const pathMastersDirectory = join(pathCacheDirectory, 'js', 'masters')
   const server = require('./server.js')
 
-  /*
-  * Check if the file is already built, and return it if that is the case
-  */
-  function checkFile () {
-    const cachedJSFile = join(pathCacheDirectory, 'js', file.replace('.src.js', '.js'))
-    if (exists(cachedJSFile)) {
-      return { file: cachedJSFile }
-    }
-  }
+  const isMastersQuery = file.startsWith('masters/')
+  const isMasterFile = await isMasterTSFile(file)
+  const TSFileCacheLocation = join(
+    isMasterFile && !isMastersQuery ? 'masters' : '',
+    file.replace(isMasterFile ? '.js' : '.src.js', '.ts')
+  )
+  const TSMastersPath = join(pathCacheDirectory, 'js', 'masters')
 
-  let foundFile = checkFile()
+  let foundFile = checkFile(file)
   if (foundFile) return foundFile
 
   // If the branch is already being compiled, get that job
-  let typescriptJob = server.getTypescriptJob(branch)
+  let typescriptJob = server.getTypescriptJob(branch, TSFileCacheLocation)
 
   // Download the source files if they are not found in the cache.
   // and a job is not currently in progress
-  if (!exists(pathMastersDirectory) && !typescriptJob) {
+  if (!(exists(pathMastersDirectory) || exists(TSMastersPath)) && !typescriptJob) {
+    log(0, `Downloading source for commit ${branch}`)
     await downloadSourceFolder(pathCacheDirectory, repositoryURL, branch)
-    if (await shouldDownloadTypeScriptFolders(repositoryURL, branch)) {
-      typescriptJob = server.addTypescriptJob(branch)
-    }
   }
 
+  // Add a typescript job, if the corresponding ts file has been downloaded,
+  // and the requested file is not downloaded
+  if (
+    !typescriptJob &&
+    exists(join(pathCacheDirectory, 'ts', TSFileCacheLocation)) &&
+    !checkFile(file)
+  ) {
+    typescriptJob = server.getTypescriptJob(branch, TSFileCacheLocation) || server.addTypescriptJob(branch, TSFileCacheLocation)
+  }
+
+  // Wait for the Typescript compilation to finish
   if (typescriptJob) {
     await typescriptJob
       .catch(error => {
-        server.removeTypescriptJob(branch)
+        server.removeTypescriptJob(branch, TSFileCacheLocation)
 
         // Fail gracefully
         log(2, `500: Typescript compilation failed:
 ${error.message}`)
       })
 
-    // Delete the typescript files after compilation is done
-    /* await removeDirectory(join(pathCacheDirectory, 'ts')) */
-
-    server.removeTypescriptJob(branch)
+    server.removeTypescriptJob(branch, TSFileCacheLocation)
   }
 
-  foundFile = checkFile()
+  // File
+  foundFile = checkFile(file)
   if (foundFile) {
     return foundFile
   }
@@ -322,7 +327,15 @@ ${error.message}`)
   return (assemble().catch((error) => {
     log(2, error.message)
     return response.notFound
+  }).finally(() => {
+    log(0, `Finished assembling ${file} for commit ${branch}`)
   }))
+
+  /* *
+   *
+   *  Scoped utility functions
+   *
+   * */
 
   /**
    * Assembles the source files
@@ -350,6 +363,39 @@ ${error.message}`)
     // Return path to file location in the cache.
     return { file: pathOutputFile }
   }
+
+  /**
+   * Checks if the file is in the ts/masters folder.
+   * If the ts/masters folder is downloaded, it will check that.
+   * Otherwise it will check Github
+   * @param {string} file
+   */
+  async function isMasterTSFile (file) {
+    // If ts folder is downloaded, check that
+    if (exists(join(pathCacheDirectory, 'ts', 'masters'))) {
+      const masterFiles = await getFileNamesInDirectory(join(pathCacheDirectory, 'ts', 'masters'), true) || []
+      return masterFiles.some(product => file.replace('.js', '.ts').startsWith(product))
+    }
+    // Otherwise check github
+    const remoteURL = URL_DOWNLOAD + branch + '/ts/masters/' + file.replace('.js', '.ts')
+    return urlExists(remoteURL)
+  }
+
+  /**
+  * Check if the file is already built, and return it if that is the case
+  * @param {string} file
+  */
+  function checkFile (file) {
+    const compiledFilePath = join(pathCacheDirectory, 'output', file)
+    const cachedJSFile =
+      exists(compiledFilePath) && !isMastersQuery
+        ? compiledFilePath
+        : join(pathCacheDirectory, 'js', isMastersQuery ? file : file.replace('.src.js', '.js'))
+
+    if (exists(cachedJSFile)) {
+      return { file: cachedJSFile }
+    }
+  }
 }
 
 /**
@@ -370,6 +416,7 @@ async function serveStaticFile (repositoryURL, requestURL) {
 
   const pathFile = join(PATH_TMP_DIRECTORY, branch, 'output', file)
   // Download the file if it is not already available in cache.
+  console.log(pathFile)
   if (!exists(pathFile)) {
     const urlFile = `${repositoryURL}${branch}/js/${file}`
     const download = await downloadFile(urlFile, pathFile)
@@ -402,7 +449,7 @@ async function serveDownloadFile (repositoryURL, branch = 'master', strParts = '
   if (!exists(join(pathCacheDirectory, 'js/masters')) || await shouldDownloadTypeScriptFolders(repositoryURL, branch)) {
     await downloadSourceFolder(pathCacheDirectory, repositoryURL, branch)
     try {
-      await compileTypeScript(branch)
+      await compileTypeScriptProject(branch)
     } catch (err) {
       throw new Error(`500: Typescript compilation failed with error:
 ${err.message}`)

--- a/app/server.js
+++ b/app/server.js
@@ -27,7 +27,8 @@ const PORT = process.env.PORT || config.port || 80
 const DATE = formatDate(new Date())
 
 const state = {
-  typescriptJobs: {}
+  typescriptJobs: {},
+  downloads: {}
 }
 
 /**
@@ -62,6 +63,32 @@ function removeTypescriptJob (branch, file) {
 function getTypescriptJob (branch, file) {
   const id = branch + file
   return state.typescriptJobs[id]
+}
+
+/**
+ * Sets a download job in the registry
+ * or returns an existing job
+ * @param {string} branch
+ * @returns {Promise<any> | undefined}
+ */
+function addDownloadJob (branch, promise) {
+  if (!state.downloads[branch]) {
+    const job = state.downloads[branch] = promise
+    return job
+  }
+}
+
+/**
+ * Get a download job from the registry
+ * @param {string} branch
+ * @returns {Promise<any> | undefined}
+ */
+function getDownloadJob (branch) {
+  return state.downloads[branch]
+}
+
+function removeDownloadJob (branch) {
+  if (state.downloads[branch]) delete state.downloads[branch]
 }
 
 // Output status information
@@ -109,5 +136,8 @@ module.exports = {
   getTypescriptJob,
   addTypescriptJob,
   removeTypescriptJob,
+  addDownloadJob,
+  getDownloadJob,
+  removeDownloadJob,
   state
 }

--- a/app/server.js
+++ b/app/server.js
@@ -1,3 +1,4 @@
+// @
 /**
  * Server application.
  * Fires up a server using ExpressJS, and registers routers, and starts listening to a port.
@@ -33,11 +34,13 @@ const state = {
  * Adds the compilation of the branch to the job registry
  * Returns the promise
  * @param {string} branch
+ * @param {string} file
  * @returns {Promise}
  */
-function addTypescriptJob (branch) {
-  if (!state.typescriptJobs[branch]) {
-    const job = state.typescriptJobs[branch] = compileTypeScript(branch)
+function addTypescriptJob (branch, file) {
+  const id = branch + file
+  if (!state.typescriptJobs[id]) {
+    const job = state.typescriptJobs[id] = compileTypeScript(branch, file)
     return job
   }
 }
@@ -45,17 +48,20 @@ function addTypescriptJob (branch) {
 /**
  * Removes a job from the registry
  * @param {*} branch
+ * @param {string} file
  */
-function removeTypescriptJob (branch) {
-  if (state.typescriptJobs[branch]) delete state.typescriptJobs[branch]
+function removeTypescriptJob (branch, file) {
+  const id = branch + file
+  if (state.typescriptJobs[id]) delete state.typescriptJobs[id]
 }
 
 /**
  * Returns a job from the registry
  * @param {*} branch
  */
-function getTypescriptJob (branch) {
-  return state.typescriptJobs[branch]
+function getTypescriptJob (branch, file) {
+  const id = branch + file
+  return state.typescriptJobs[id]
 }
 
 // Output status information

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github.highcharts.com",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github.highcharts.com",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Node.js server which runs a RESTful application to serve Highcharts scripts built from the Highcharts build script.",
   "main": "server.js",
   "dependencies": {

--- a/test/download.js
+++ b/test/download.js
@@ -71,13 +71,13 @@ describe('download.js', () => {
     })
     it('should resolve with an informational object, and a newly created file.', () => {
       return downloadFile(
-        downloadURL + 'master/js/masters/highcharts.src.js',
+        downloadURL + 'master/ts/masters/highcharts.src.ts',
         './tmp/test/downloaded-file1.js'
       ).then(({ outputPath, statusCode, success, url }) => {
         expect(outputPath).to.equal('./tmp/test/downloaded-file1.js')
         expect(statusCode).to.equal(200)
         expect(success).to.equal(true)
-        expect(url).to.equal(downloadURL + 'master/js/masters/highcharts.src.js')
+        expect(url).to.equal(downloadURL + 'master/ts/masters/highcharts.src.ts')
         expect(fs.lstatSync('./tmp/test/downloaded-file1.js').size).to.be.greaterThan(0)
       })
     })

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -19,6 +19,7 @@ describe('utilities.js', () => {
       'log',
       'padStart',
       'compileTypeScript',
+      'compileTypeScriptProject',
       'getGlobalsLocation',
       'updateBranchAccess'
     ]


### PR DESCRIPTION
* Changed the typescript compilation to only compile the requested file instead of the whole project.
* Implemented a download registry to reduce the amount of request to Github

This is currently live, will merge if the server can handle the slightly increased workload (in cases with multiple imports from a single branch) and no unintended consequences occurs. FYI @TorsteinHonsi 